### PR TITLE
feat(compiler)!: stricter CompilerOptions type

### DIFF
--- a/source/compiler.ts
+++ b/source/compiler.ts
@@ -8,13 +8,24 @@ import * as ts from "typescript";
 // There is an example that uses the LanguageService here:
 // https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#incremental-build-support-using-the-language-services
 
+// prettier-ignore
+export type CompilerOptions = {
+  [K in keyof ts.CompilerOptions]: ts.CompilerOptions[K] | (
+    K extends 'moduleResolution' ? 'node'|'classic' :
+    K extends 'target' ? keyof typeof ts.ScriptTarget | (
+      'es3'|'es5'|'es6'|'es2015'|'es2016'|'es2017'|'es2018'|'es2019'|'es2020'|'esnext'
+    ) :
+    void
+  )
+}
+
 export class Compiler {
   private _compilerOptions: ts.CompilerOptions;
   private _files: ts.MapLike<{ content: string; version: number }>;
   private _languageService: ts.LanguageService;
 
   constructor(
-    compilerOptions: object = {},
+    compilerOptions: CompilerOptions = {},
     rootDirectory: string = process.cwd()
   ) {
     function normalize(path: string): string {

--- a/source/expecter.ts
+++ b/source/expecter.ts
@@ -3,7 +3,7 @@
  * can be found in the LICENSE file at https://github.com/cartant/ts-snippet
  */
 
-import { Compiler } from "./compiler";
+import { Compiler, CompilerOptions } from "./compiler";
 import { Expect } from "./expect";
 import { snippet } from "./snippet";
 
@@ -13,12 +13,12 @@ export function expecter(
 ): (code: string) => Expect;
 export function expecter(
   factory?: (code: string) => string,
-  compilerOptions?: object,
+  compilerOptions?: CompilerOptions,
   rootDirectory?: string
 ): (code: string) => Expect;
 export function expecter(
   factory: (code: string) => string = (code) => code,
-  compilerOrOptions?: Compiler | object,
+  compilerOrOptions?: Compiler | CompilerOptions,
   rootDirectory?: string
 ): (code: string) => Expect {
   const compiler =


### PR DESCRIPTION
I wanted intellisense, so I changed compiler options type to match actual TS compiler options and added extra values supported by TS but for some reason absent from their enum types.