### PR TITLE
Don't show expected error for comparison when no error was received

### DIFF
--- a/source/snippet.ts
+++ b/source/snippet.ts
@@ -38,12 +38,14 @@ export class Snippet {
       expectedMessage ? expectedMessage.test(message) : true
     );
     if (!matched) {
+      const receivedMessages = new Set(messages);
+
       this.assertFail(
-        expectedMessage
+        expectedMessage && receivedMessages.size > 0
           ? `Expected an error matching:
 ${expectedMessage}
 but received:
-${[...new Set(messages)].join("\n")}`
+${[...receivedMessages].join("\n")}`
           : "Expected an error"
       );
     } else {


### PR DESCRIPTION
Hi @cartant :wave: 

I got this

![image](https://user-images.githubusercontent.com/15332326/100934710-7209b900-34ef-11eb-927d-fbd379ea90cf.png)

> Expected an error matching ERROR_MESSAGE but received:
> at position atFail
> ERROR_MESSAGE

🤔

and I read it about 10 times, quite puzzled, before I opened the code and realized that there's `received: <no error message>` there :D 
I'm still smiling. I hope it makes you smile too.